### PR TITLE
Fix mobile crash from window event

### DIFF
--- a/brain-nourishment-app/games/ReactionGame.jsx
+++ b/brain-nourishment-app/games/ReactionGame.jsx
@@ -76,14 +76,11 @@ export default function ReactionGame() {
       }
     };
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('keydown', handleKeyDown);
-    }
+    const win = typeof window !== 'undefined' ? window : undefined;
+    win?.addEventListener?.('keydown', handleKeyDown);
 
     return () => {
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('keydown', handleKeyDown);
-      }
+      win?.removeEventListener?.('keydown', handleKeyDown);
     };
   }, [gameState]);
 


### PR DESCRIPTION
## Summary
- guard `window` event listeners so they don't run on React Native

## Testing
- `npm test --prefix brain-nourishment-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9dcb6308325b9dfaeaeb4171561