### PR TITLE
Add Jest tests for screens

### DIFF
--- a/brain-nourishment-app/__tests__/ColorMatchIntro.test.jsx
+++ b/brain-nourishment-app/__tests__/ColorMatchIntro.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ColorMatchIntro from '../screens/ColorMatchIntro';
+import { NavigationContainer } from '@react-navigation/native';
+
+describe('ColorMatchIntro', () => {
+  it('renders intro screen', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <ColorMatchIntro />
+      </NavigationContainer>
+    );
+    expect(getByText('Color Match')).toBeTruthy();
+    expect(getByText('Start')).toBeTruthy();
+  });
+});

--- a/brain-nourishment-app/__tests__/Highscores.test.jsx
+++ b/brain-nourishment-app/__tests__/Highscores.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import Highscores from '../screens/Highscores';
+import { NavigationContainer } from '@react-navigation/native';
+
+describe('Highscores', () => {
+  it('renders list titles', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <Highscores />
+      </NavigationContainer>
+    );
+    expect(getByText('Reaction Time')).toBeTruthy();
+    expect(getByText('Color Match')).toBeTruthy();
+    expect(getByText('Tap the Target')).toBeTruthy();
+  });
+});

--- a/brain-nourishment-app/__tests__/HomeScreen.test.jsx
+++ b/brain-nourishment-app/__tests__/HomeScreen.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import HomeScreen from '../screens/HomeScreen';
+import { NavigationContainer } from '@react-navigation/native';
+
+describe('HomeScreen', () => {
+  it('shows buttons for each game', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <HomeScreen />
+      </NavigationContainer>
+    );
+
+    expect(getByText('Reaction Time')).toBeTruthy();
+    expect(getByText('Color Match')).toBeTruthy();
+    expect(getByText('Tap the Target')).toBeTruthy();
+    expect(getByText('Highscores')).toBeTruthy();
+  });
+});

--- a/brain-nourishment-app/__tests__/PreGameScreen.test.jsx
+++ b/brain-nourishment-app/__tests__/PreGameScreen.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PreGameScreen from '../components/PreGameScreen';
+
+const props = {
+  icon: '⚡',
+  gameTitle: 'Test Game',
+  description: 'desc',
+  highscoreKey: 'hs-key',
+  onStart: jest.fn(),
+  onInfo: jest.fn(),
+  onBack: jest.fn(),
+};
+
+describe('PreGameScreen', () => {
+  it('renders title and calls callbacks', () => {
+    const { getByText } = render(<PreGameScreen {...props} />);
+    expect(getByText('Test Game')).toBeTruthy();
+
+    fireEvent.press(getByText('Start'));
+    expect(props.onStart).toHaveBeenCalled();
+
+    fireEvent.press(getByText('information-circle-outline'));
+    expect(props.onInfo).toHaveBeenCalled();
+  });
+});

--- a/brain-nourishment-app/__tests__/ReactionGameIntro.test.jsx
+++ b/brain-nourishment-app/__tests__/ReactionGameIntro.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ReactionGameIntro from '../screens/ReactionGameIntro';
+import { NavigationContainer } from '@react-navigation/native';
+
+describe('ReactionGameIntro', () => {
+  it('renders intro screen', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <ReactionGameIntro />
+      </NavigationContainer>
+    );
+    expect(getByText('Reaction Time')).toBeTruthy();
+    expect(getByText('Start')).toBeTruthy();
+  });
+});

--- a/brain-nourishment-app/__tests__/TapTheTargetIntro.test.jsx
+++ b/brain-nourishment-app/__tests__/TapTheTargetIntro.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import TapTheTargetIntro from '../screens/TapTheTargetIntro';
+import { NavigationContainer } from '@react-navigation/native';
+
+describe('TapTheTargetIntro', () => {
+  it('renders intro screen', () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <TapTheTargetIntro />
+      </NavigationContainer>
+    );
+    expect(getByText('Tap the Target')).toBeTruthy();
+    expect(getByText('Start')).toBeTruthy();
+  });
+});

--- a/brain-nourishment-app/jest.setup.js
+++ b/brain-nourishment-app/jest.setup.js
@@ -1,0 +1,17 @@
+import '@testing-library/jest-native/extend-expect';
+
+// Simple mock for Ionicons to avoid loading native modules
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  return {
+    Ionicons: (props) => {
+      return React.createElement('Icon', props, props.name || 'icon');
+    },
+  };
+});
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(() => Promise.resolve(null)),
+  setItem: jest.fn(() => Promise.resolve()),
+}));

--- a/brain-nourishment-app/package.json
+++ b/brain-nourishment-app/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
@@ -28,6 +29,10 @@
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.2.0",
     "jest": "^30.0.4"
+  },
+  "jest": {
+    "preset": "react-native",
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- configure Jest for React Native
- mock Ionicons and AsyncStorage in `jest.setup.js`
- test PreGameScreen callbacks
- test all screen components render correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867baae85c48325994dcea0385719d6