### PR TITLE
Fix event listener crash on native

### DIFF
--- a/brain-nourishment-app/games/ColorMatchGame.jsx
+++ b/brain-nourishment-app/games/ColorMatchGame.jsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Vibration,
+  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -68,16 +69,18 @@ export default function ColorMatchGame() {
     if (isGameOver) checkAndSaveHighscore(score);
   }, [isGameOver]);
 
-  // Tasteneingabe für Web
+  // Tasteneingabe nur im Web
   useEffect(() => {
-    const handleKeyPress = (event) => {
-      if (isGameOver || isDisabled) return;
-      if (event.key === '1') handleAnswer(false);
-      if (event.key === '2') handleAnswer(true);
-    };
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      const handleKeyPress = (event) => {
+        if (isGameOver || isDisabled) return;
+        if (event.key === '1') handleAnswer(false);
+        if (event.key === '2') handleAnswer(true);
+      };
 
-    window?.addEventListener?.('keydown', handleKeyPress);
-    return () => window?.removeEventListener?.('keydown', handleKeyPress);
+      window.addEventListener('keydown', handleKeyPress);
+      return () => window.removeEventListener('keydown', handleKeyPress);
+    }
   }, [isGameOver, isDisabled, isMatch]);
 
   const checkAndSaveHighscore = async (finalScore) => {

--- a/brain-nourishment-app/games/ReactionGame.jsx
+++ b/brain-nourishment-app/games/ReactionGame.jsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   TouchableOpacity,
   Vibration,
+  Platform,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
@@ -67,21 +68,19 @@ export default function ReactionGame() {
     }
   }, [gameState]);
 
-  // Spacebar-Tastendruck erlaubt Reaktion auf Web
+  // Spacebar-Tastendruck nur im Web
   useEffect(() => {
-    const handleKeyDown = (event) => {
-      if (event.code === 'Space') {
-        event.preventDefault();
-        handlePress();
-      }
-    };
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      const handleKeyDown = (event) => {
+        if (event.code === 'Space') {
+          event.preventDefault();
+          handlePress();
+        }
+      };
 
-    const win = typeof window !== 'undefined' ? window : undefined;
-    win?.addEventListener?.('keydown', handleKeyDown);
-
-    return () => {
-      win?.removeEventListener?.('keydown', handleKeyDown);
-    };
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }
   }, [gameState]);
 
   // Nutzer hat den Bildschirm getippt


### PR DESCRIPTION
## Summary
- avoid window listeners on native platforms in ColorMatchGame and ReactionGame

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6867bde8e2748325b496f22148ed4089