### PR TITLE
Add info screens for games

### DIFF
--- a/brain-nourishment-app/navigation/StackNavigator.jsx
+++ b/brain-nourishment-app/navigation/StackNavigator.jsx
@@ -7,6 +7,9 @@ import ColorMatchGame from '../games/ColorMatchGame';
 import TapTheTargetIntro from '../screens/TapTheTargetIntro';
 import TapTheTargetGame from '../games/TapTheTargetGame';
 import Highscores from '../screens/Highscores';
+import ReactionInfo from '../screens/ReactionInfo';
+import ColorMatchInfo from '../screens/ColorMatchInfo';
+import TapTheTargetInfo from '../screens/TapTheTargetInfo';
 
 const Stack = createNativeStackNavigator();
 
@@ -20,6 +23,9 @@ export default function StackNavigator() {
       <Stack.Screen name="ColorMatchGame" component={ColorMatchGame} options={{ headerShown: false }}/>
       <Stack.Screen name="TapTheTargetIntro" component={TapTheTargetIntro} options={{ headerShown: false }}/>
       <Stack.Screen name="TapTheTargetGame" component={TapTheTargetGame} options={{ headerShown: false }}/>
+      <Stack.Screen name="ReactionInfo" component={ReactionInfo} options={{ headerShown: false }}/>
+      <Stack.Screen name="ColorMatchInfo" component={ColorMatchInfo} options={{ headerShown: false }}/>
+      <Stack.Screen name="TapTheTargetInfo" component={TapTheTargetInfo} options={{ headerShown: false }}/>
       <Stack.Screen name="Highscores" component={Highscores} options={{ headerShown: false }}/>
     </Stack.Navigator>
   );

--- a/brain-nourishment-app/screens/ColorMatchInfo.jsx
+++ b/brain-nourishment-app/screens/ColorMatchInfo.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+
+export default function ColorMatchInfo() {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
+        <Ionicons name="arrow-back" size={24} color="#000" />
+        <Text style={styles.backText}>Zurück</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>Color Match</Text>
+      <Text style={styles.text}>
+        Entscheide, ob die Farbe des Wortes zur Bedeutung passt. Tippe auf
+        "Falsch" oder "Richtig", bevor die Zeit abläuft.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60, paddingHorizontal: 20, backgroundColor: '#fff' },
+  backButton: { position: 'absolute', top: 40, left: 20, flexDirection: 'row', alignItems: 'center' },
+  backText: { marginLeft: 5, fontSize: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
+  text: { fontSize: 16, lineHeight: 22 },
+});

--- a/brain-nourishment-app/screens/ReactionInfo.jsx
+++ b/brain-nourishment-app/screens/ReactionInfo.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+
+export default function ReactionInfo() {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
+        <Ionicons name="arrow-back" size={24} color="#000" />
+        <Text style={styles.backText}>Zurück</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>Reaction Time</Text>
+      <Text style={styles.text}>
+        Warte, bis der Bildschirm grün wird, und tippe dann so schnell wie
+        möglich. Deine Reaktionszeit wird gemessen.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60, paddingHorizontal: 20, backgroundColor: '#fff' },
+  backButton: { position: 'absolute', top: 40, left: 20, flexDirection: 'row', alignItems: 'center' },
+  backText: { marginLeft: 5, fontSize: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
+  text: { fontSize: 16, lineHeight: 22 },
+});

--- a/brain-nourishment-app/screens/TapTheTargetInfo.jsx
+++ b/brain-nourishment-app/screens/TapTheTargetInfo.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+
+export default function TapTheTargetInfo() {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
+        <Ionicons name="arrow-back" size={24} color="#000" />
+        <Text style={styles.backText}>Zurück</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>Tap the Target</Text>
+      <Text style={styles.text}>
+        Tippe nacheinander auf alle Ziele, bevor sie verschwinden. Die
+        Reaktionszeit wird immer kürzer.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60, paddingHorizontal: 20, backgroundColor: '#fff' },
+  backButton: { position: 'absolute', top: 40, left: 20, flexDirection: 'row', alignItems: 'center' },
+  backText: { marginLeft: 5, fontSize: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
+  text: { fontSize: 16, lineHeight: 22 },
+});


### PR DESCRIPTION
## Summary
- add ReactionInfo, ColorMatchInfo and TapTheTargetInfo screens
- register new screens in StackNavigator

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867bdcb5c7c8325aa85e5a7cfb670e0