### PR TITLE
Guard keyboard listeners on native

### DIFF
--- a/brain-nourishment-app/games/ColorMatchGame.jsx
+++ b/brain-nourishment-app/games/ColorMatchGame.jsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Vibration,
+  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -68,16 +69,18 @@ export default function ColorMatchGame() {
     if (isGameOver) checkAndSaveHighscore(score);
   }, [isGameOver]);
 
-  // Tasteneingabe für Web
+  // Tasteneingabe nur im Web
   useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+
     const handleKeyPress = (event) => {
       if (isGameOver || isDisabled) return;
       if (event.key === '1') handleAnswer(false);
       if (event.key === '2') handleAnswer(true);
     };
 
-    window?.addEventListener?.('keydown', handleKeyPress);
-    return () => window?.removeEventListener?.('keydown', handleKeyPress);
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
   }, [isGameOver, isDisabled, isMatch]);
 
   const checkAndSaveHighscore = async (finalScore) => {

--- a/brain-nourishment-app/games/ReactionGame.jsx
+++ b/brain-nourishment-app/games/ReactionGame.jsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   TouchableOpacity,
   Vibration,
+  Platform,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
@@ -67,8 +68,10 @@ export default function ReactionGame() {
     }
   }, [gameState]);
 
-  // Spacebar-Tastendruck erlaubt Reaktion auf Web
+  // Spacebar-Tastendruck nur im Web
   useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+
     const handleKeyDown = (event) => {
       if (event.code === 'Space') {
         event.preventDefault();
@@ -76,11 +79,10 @@ export default function ReactionGame() {
       }
     };
 
-    const win = typeof window !== 'undefined' ? window : undefined;
-    win?.addEventListener?.('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      win?.removeEventListener?.('keydown', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown);
     };
   }, [gameState]);
 


### PR DESCRIPTION
## Summary
- import `Platform` from React Native
- add platform checks before attaching global window event listeners

## Testing
- `npx jest` *(fails: jest package can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867bddc3f488325b7ffe2b1a8301cbd